### PR TITLE
Installation script for ClamXav

### DIFF
--- a/install_clam
+++ b/install_clam
@@ -1,0 +1,107 @@
+#!/bin/bash
+
+set -e
+
+PATH=/bin:/usr/bin:/usr/sbin
+
+#
+# Configuration
+# --------------------------------------------
+
+# Configure URL and checksum if installing different version
+#
+URL=http://www.clamxav.com/downloads/ClamXav_2.7.5.dmg
+SHA=edf4e44a1b58bb01cda49e9c51766c4d26620400
+DMG=/tmp/clamxav.dmg
+
+
+test -d /Applications/ClamXav.app && { echo "Please uninstall ClamXAv first"; exit 1; }
+
+USER=$(whoami)
+# Configuratipn ends here
+# --------------------------------------------
+sudo -l > /dev/null
+
+curl ${URL} -o ${DMG}
+
+REAL_SHA=$(openssl sha1 ${DMG} |awk '{print $2}')
+
+test ${SHA} == ${REAL_SHA} || { echo "Error verifying DMG checksum"; exit 1; }
+
+DEVICE=$(hdiutil mount ${DMG} | awk '$3 ~ /Volumes/ {print $1}' 2> /dev/null)
+
+sudo cp -R "/Volumes/ClamXav/ClamXav.app" /Applications
+
+hdiutil detach ${DEVICE}
+
+open /Applications/ClamXav.app &
+
+cat <<EOF > ~/Library/LaunchAgents/uk.co.markallan.clamxav.sentry.plist
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>Label</key>
+	<string>uk.co.markallan.clamxav.sentry</string>
+	<key>OnDemand</key>
+	<true/>
+    <key>KeepAlive</key>
+    <dict>
+      <key>OtherJobEnabled</key>
+      <dict>
+         <key>com.clamav.clamd</key>
+         <false/>
+      </dict>
+    </dict>
+
+    <key>LimitLoadToSessionType</key>
+    <string>Aqua</string>
+
+	<key>ProgramArguments</key>
+	<array>
+		<string>/Applications/ClamXav.app/Contents/Resources/ClamXav Sentry.app/Contents/MacOS/ClamXav Sentry</string>
+	</array>
+	<key>RunAtLoad</key>
+	<true/>
+    <key>UserName</key>
+    <string>${USER}</string>
+</dict>
+</plist>
+EOF
+
+cat <<EOF > ~/Library/LaunchAgents/uk.co.markallan.clamxav.freshclam.plist
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>Label</key>
+	<string>uk.co.markallan.clamxav.freshclam</string>
+	<key>OnDemand</key>
+	<true/>
+	<key>ProgramArguments</key>
+	<array>
+		<string>/Applications/ClamXav.app/Contents/Resources/ScheduleHelper</string>
+		<string>update</string>
+	</array>
+	<key>RunAtLoad</key>
+	<false/>
+	<key>StartCalendarInterval</key>
+	<array>
+		<dict>
+			<key>Hour</key>
+			<integer>0</integer>
+			<key>Minute</key>
+			<integer>45</integer>
+		</dict>
+	</array>
+</dict>
+</plist>
+
+EOF
+
+for i in uk.co.markallan.clamxav.freshclam.plist uk.co.markallan.clamxav.sentry.plist; do
+
+    sudo chown root:staff ~/Library/LaunchAgents/$i
+    sudo chmod 644 ~/Library/LaunchAgents/$i
+    sudo launchctl load ~/Library/LaunchAgents/$i
+done


### PR DESCRIPTION
@zentahori Please review.

This installs ClamXav and configures `launchd` for Frashclam (virus pattern updater) and for background realtime scanner Clamav Sentry. 